### PR TITLE
Complete site pages and gallery components

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,0 +1,24 @@
+export default function AboutPage() {
+  return (
+    <section className="content-section about-page">
+      <h2 className="section-title">About Saudade</h2>
+      <div className="about-content-layout">
+        <div className="about-text">
+          <p>
+            Saudade is a collective of music lovers hosting events and sessions
+            in Enschede. We aim to bring people together through deep and
+            soulful house music.
+          </p>
+          <p>
+            Our team curates unique experiences where everyone can feel the
+            rhythm and share good vibes. Join us for our next session or browse
+            the gallery of our past events.
+          </p>
+        </div>
+        <div className="about-image">
+          <img src="/assets/images/about-image.png" alt="About Saudade" />
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,0 +1,28 @@
+export default function ContactPage() {
+  return (
+    <section className="content-section contact-page">
+      <h2 className="section-title">Get in Touch</h2>
+      <div className="contact-info">
+        <p className="contact-email">
+          Email us at <a href="mailto:info@saudade.com">info@saudade.com</a>
+        </p>
+        <p>Enschede, Netherlands</p>
+      </div>
+      <div className="social-links">
+        <h3>Follow Us</h3>
+        <ul>
+          <li>
+            <a href="#" aria-label="Instagram">
+              <span className="sr-only">Instagram</span>📸
+            </a>
+          </li>
+          <li>
+            <a href="#" aria-label="SoundCloud">
+              <span className="sr-only">SoundCloud</span>🎵
+            </a>
+          </li>
+        </ul>
+      </div>
+    </section>
+  );
+}

--- a/src/app/gallery/[slug]/page.tsx
+++ b/src/app/gallery/[slug]/page.tsx
@@ -1,11 +1,7 @@
 // src/app/gallery/[slug]/page.tsx
 import { notFound } from "next/navigation";
 import Link from "next/link";
-import {
-  GalleryOverviewItem,
-  galleryOverview,
-  galleryDetails,
-} from "@/data/gallery";
+import { galleryOverview, galleryDetails } from "@/data/gallery";
 
 interface Props {
   params: { slug: string };

--- a/src/app/gallery/page.tsx
+++ b/src/app/gallery/page.tsx
@@ -1,0 +1,11 @@
+import { galleryOverview } from "@/data/gallery";
+import { GalleryGrid } from "@/components/GalleryGrid";
+
+export default function GalleryPage() {
+  return (
+    <section className="content-section">
+      <h2 className="section-title">Event Galleries</h2>
+      <GalleryGrid items={galleryOverview} />
+    </section>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -42,7 +42,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="en" className="antialiased">
+    <html lang="en" className={`${josefin.variable} antialiased`}>
       <body className="bg-gray-900 text-gray-100 antialiased">
         <Header />
         <main className="pt-16">{children}</main>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,29 +1,21 @@
 // src/app/page.tsx
 import { Hero } from "@/components/Hero";
+import { events } from "@/data/events";
+import { EventCard } from "@/components/EventCard";
 
 export default function Home() {
+  const nextEvent = events.find((e) => !e.past);
   return (
     <>
       <Hero />
-      {/* Next Event */}
-      <section className="content-section upcoming-event">
-        <h2 className="section-title fade-slide fade-delay-7">Next Event</h2>
-        <div className="event-details fade-slide fade-delay-8">
-          <h3 className="event-title">Saudade Summer Sessions</h3>
-          <p className="event-date-venue">
-            <span className="event-date">Saturday, May 10th, 2025</span> |{" "}
-            <span className="event-venue">TBA, Enschede</span>
-          </p>
-          <p className="event-description">
-            Welcoming summer with Saudade. More details coming soon!
-          </p>
-          <div className="event-links">
-            <a href="#" className="event-ticket-button disabled">
-              Tickets Coming Soon
-            </a>
+      {nextEvent && (
+        <section className="content-section upcoming-event">
+          <h2 className="section-title fade-slide fade-delay-7">Next Event</h2>
+          <div className="fade-slide fade-delay-8">
+            <EventCard {...nextEvent} />
           </div>
-        </div>
-      </section>
+        </section>
+      )}
     </>
   );
 }

--- a/src/components/EventCard.tsx
+++ b/src/components/EventCard.tsx
@@ -1,0 +1,26 @@
+import Link from "next/link";
+import { Event } from "@/data/events";
+
+export function EventCard({ title, date, venue, description, cta }: Event) {
+  return (
+    <div className="event-listing">
+      <h3 className="event-title">{title}</h3>
+      <p className="event-date-venue">
+        <span>{date}</span> | <span>{venue}</span>
+      </p>
+      <p className="event-description">{description}</p>
+      <div className="event-links">
+        {cta.href.startsWith("http") || cta.href.startsWith("/") ? (
+          <Link
+            href={cta.href}
+            className={`event-ticket-button ${cta.disabled ? "disabled" : ""}`}
+          >
+            {cta.label}
+          </Link>
+        ) : (
+          <span className="event-ticket-button disabled">{cta.label}</span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/GalleryGrid.tsx
+++ b/src/components/GalleryGrid.tsx
@@ -1,0 +1,16 @@
+import { GalleryOverviewItem } from "@/data/gallery";
+import { GalleryItem } from "./GalleryItem";
+
+interface Props {
+  items: GalleryOverviewItem[];
+}
+
+export function GalleryGrid({ items }: Props) {
+  return (
+    <div className="gallery-grid">
+      {items.map((item) => (
+        <GalleryItem key={item.slug} item={item} />
+      ))}
+    </div>
+  );
+}

--- a/src/components/GalleryItem.tsx
+++ b/src/components/GalleryItem.tsx
@@ -1,0 +1,25 @@
+import Link from "next/link";
+import { GalleryOverviewItem } from "@/data/gallery";
+
+interface Props {
+  item: GalleryOverviewItem;
+}
+
+export function GalleryItem({ item }: Props) {
+  return (
+    <Link
+      href={`/gallery/${item.slug}`}
+      className="gallery-item block overflow-hidden rounded-lg shadow-lg"
+    >
+      <img
+        src={item.thumbnail}
+        alt={`${item.title} thumbnail`}
+        className="gallery-thumbnail"
+      />
+      <div className="gallery-item-overlay">
+        <div className="gallery-item-title">{item.title}</div>
+        <div className="gallery-item-date">{item.date}</div>
+      </div>
+    </Link>
+  );
+}


### PR DESCRIPTION
## Summary
- add About and Contact page content
- add Gallery index page with grid and item components
- hook up next event to use EventCard on home page
- implement EventCard, GalleryGrid, and GalleryItem components
- small cleanup in layout and gallery detail page

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font `Josefin Sans`)*

------
https://chatgpt.com/codex/tasks/task_e_68459a4b3aa4833197392278da480d26